### PR TITLE
Add Mocha tests for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ Using Postman:
 
 Test all API endpoints (e.g., /api/signup, /api/login, /api/food_posts).
 Verify user authentication and food reservation logic.
+
+Automated Testing:
+Run all Mocha tests with:
+
+```bash
+npm test
+```
 Frontend Testing:
 
 Use a browser to test:

--- a/package.json
+++ b/package.json
@@ -8,5 +8,13 @@
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.11.5",
     "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "chai": "^4.3.10",
+    "mocha": "^10.2.0",
+    "supertest": "^6.3.4"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/server.js
+++ b/server.js
@@ -16,11 +16,13 @@ const SECRET_KEY = "1993";
 // Middleware
 app.use(bodyParser.json());
 
-// Start the server
+// Start the server only if this file is run directly
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
 
 function authenticateToken(req, res, next) {
   const authHeader = req.headers['authorization'];
@@ -156,3 +158,5 @@ catch (error) {
 }
 
 });
+
+module.exports = app;

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,60 @@
+const request = require('supertest');
+const { expect } = require('chai');
+
+// In-memory mock database
+const users = [];
+let nextId = 1;
+const dbMock = {
+  query: async (sql, params) => {
+    if (sql.startsWith('SELECT * FROM users WHERE email')) {
+      const email = params[0];
+      const match = users.filter(u => u.email === email);
+      return [match];
+    }
+    if (sql.startsWith('INSERT INTO users')) {
+      const [username, email, password] = params;
+      const user = { user_id: nextId++, username, email, password };
+      users.push(user);
+      return [{ insertId: user.user_id }];
+    }
+    throw new Error('Unsupported query in test: ' + sql);
+  }
+};
+
+before(() => {
+  // Replace the db module with the mock
+  require.cache[require.resolve('../db')] = { exports: dbMock };
+  // Require the server after mocking db
+  app = require('../server');
+});
+
+beforeEach(() => {
+  users.length = 0;
+  nextId = 1;
+});
+
+describe('Auth API', () => {
+  it('should sign up and log in successfully', async () => {
+    const signupRes = await request(app)
+      .post('/api/signup')
+      .send({ username: 'test', email: 'test@example.com', password: 'pass123' });
+    expect(signupRes.status).to.equal(201);
+
+    const loginRes = await request(app)
+      .post('/api/login')
+      .send({ email: 'test@example.com', password: 'pass123' });
+    expect(loginRes.status).to.equal(200);
+    expect(loginRes.body).to.have.property('token');
+  });
+
+  it('should reject signup with existing email', async () => {
+    await request(app)
+      .post('/api/signup')
+      .send({ username: 'one', email: 'dup@example.com', password: 'pass' });
+
+    const dupRes = await request(app)
+      .post('/api/signup')
+      .send({ username: 'two', email: 'dup@example.com', password: 'pass' });
+    expect(dupRes.status).to.equal(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha, supertest and chai as dev dependencies
- export Express app and only start server when run directly
- add automated tests for `/api/signup` and `/api/login`
- document running the tests in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b513814832d997195945f11973e