### PR TITLE
Serve frontend with Express and clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ Copy code
 npm start
 The server will run at: http://localhost:3000
 
-Run the Frontend Open index.html in your browser to interact with the application.
+Run the Frontend:
+After starting the server, open your browser to:
+
+```
+http://localhost:3000/
+```
+
+The server serves the frontend files from the `frontend` directory.
 
 API Endpoints
 Authentication
@@ -151,6 +158,13 @@ Using Postman:
 
 Test all API endpoints (e.g., /api/signup, /api/login, /api/food_posts).
 Verify user authentication and food reservation logic.
+
+Automated Testing:
+Run all Mocha tests with:
+
+```bash
+npm test
+```
 Frontend Testing:
 
 Use a browser to test:

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -36,7 +36,7 @@ async function loadUserFoodPosts() {
     }
 
     try {
-        const response = await fetch('http://localhost:3000/api/user_food_posts', {
+        const response = await fetch('/api/user_food_posts', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
 
@@ -81,7 +81,7 @@ function setupSignupForm() {
             const password = document.getElementById('password').value;
 
             try {
-                const response = await fetch('http://localhost:3000/api/signup', {
+                const response = await fetch('/api/signup', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ username, email, password }),
@@ -115,7 +115,7 @@ function setupLoginForm() {
             const password = document.getElementById('password').value;
 
             try {
-                const response = await fetch('http://localhost:3000/api/login', {
+                const response = await fetch('/api/login', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ email, password }),
@@ -158,7 +158,7 @@ function setupFoodPostForm() {
             const contactInfo = document.getElementById('contact-info').value;
 
             try {
-                const response = await fetch('http://localhost:3000/api/food_posts', {
+                const response = await fetch('/api/food_posts', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -186,7 +186,7 @@ function setupFoodPostForm() {
  */
 async function loadFoodPosts() {
     try {
-        const response = await fetch('http://localhost:3000/api/food_posts');
+        const response = await fetch('/api/food_posts');
         if (!response.ok) throw new Error('Failed to fetch food posts.');
 
         const foodPosts = await response.json();
@@ -251,7 +251,7 @@ async function reserveFood(postId) {
     }
 
     try {
-        const response = await fetch(`http://localhost:3000/api/food_posts/${postId}/reserved`, {
+        const response = await fetch(`/api/food_posts/${postId}/reserved`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',

--- a/package.json
+++ b/package.json
@@ -8,5 +8,14 @@
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.11.5",
     "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "chai": "^4.3.10",
+    "mocha": "^10.2.0",
+    "supertest": "^6.3.4"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "test": "mocha"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,10 +5,12 @@ const express = require('express');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const db = require('./db');
+const path = require('path');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, 'frontend')));
 
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
@@ -16,11 +18,18 @@ const SECRET_KEY = "1993";
 // Middleware
 app.use(bodyParser.json());
 
-// Start the server
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
+// Serve static frontend files
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend', 'index.html'));
 });
+
+// Start the server only if this file is run directly
+const PORT = process.env.PORT || 3000;
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
 
 function authenticateToken(req, res, next) {
   const authHeader = req.headers['authorization'];
@@ -156,3 +165,5 @@ catch (error) {
 }
 
 });
+
+module.exports = app;

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const { expect } = require('chai');
+
+// In-memory mock database
+const users = [];
+let nextId = 1;
+let app;
+const dbMock = {
+  query: async (sql, params) => {
+    if (sql.startsWith('SELECT * FROM users WHERE email')) {
+      const email = params[0];
+      const match = users.filter(u => u.email === email);
+      return [match];
+    }
+    if (sql.startsWith('INSERT INTO users')) {
+      const [username, email, password] = params;
+      const user = { user_id: nextId++, username, email, password };
+      users.push(user);
+      return [{ insertId: user.user_id }];
+    }
+    throw new Error('Unsupported query in test: ' + sql);
+  }
+};
+
+before(() => {
+  // Replace the db module with the mock
+  require.cache[require.resolve('../db')] = { exports: dbMock };
+  // Require the server after mocking db
+  app = require('../server');
+});
+
+beforeEach(() => {
+  users.length = 0;
+  nextId = 1;
+});
+
+describe('Auth API', () => {
+  it('should sign up and log in successfully', async () => {
+    const signupRes = await request(app)
+      .post('/api/signup')
+      .send({ username: 'test', email: 'test@example.com', password: 'pass123' });
+    expect(signupRes.status).to.equal(201);
+
+    const loginRes = await request(app)
+      .post('/api/login')
+      .send({ email: 'test@example.com', password: 'pass123' });
+    expect(loginRes.status).to.equal(200);
+    expect(loginRes.body).to.have.property('token');
+  });
+
+  it('should reject signup with existing email', async () => {
+    await request(app)
+      .post('/api/signup')
+      .send({ username: 'one', email: 'dup@example.com', password: 'pass' });
+
+    const dupRes = await request(app)
+      .post('/api/signup')
+      .send({ username: 'two', email: 'dup@example.com', password: 'pass' });
+    expect(dupRes.status).to.equal(400);
+  });
+});


### PR DESCRIPTION
## Summary
- serve `frontend` directory via Express
- add route for `/` to load `index.html`
- document how to access the frontend through the running server
- define `start` script in `package.json`
- initialize app variable in tests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b513814832d997195945f11973e